### PR TITLE
Allow simple expansion variables to start with a number

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -286,8 +286,10 @@ func lexStartExpansion(l *lexer) stateFn {
 		l.ignore()
 		l.depth++
 		return lexBracketName
-	case isAlphaNum(c):
+	case isAlpha(c):
 		return lexSimpleName
+	case isNum(c):
+		return lexNumberName
 	}
 	return nil // FIXME
 }
@@ -301,6 +303,18 @@ func lexEndBracket(l *lexer) stateFn {
 func lexSimpleName(l *lexer) stateFn {
 	for {
 		if !isAlphaNum(l.next()) {
+			l.backup()
+			name := l.token()
+			l.emit(itemReadParam(name))
+			l.ignore()
+			return lexText
+		}
+	}
+}
+
+func lexNumberName(l *lexer) stateFn {
+	for {
+		if !isNum(l.next()) {
 			l.backup()
 			name := l.token()
 			l.emit(itemReadParam(name))

--- a/lexer.go
+++ b/lexer.go
@@ -286,7 +286,7 @@ func lexStartExpansion(l *lexer) stateFn {
 		l.ignore()
 		l.depth++
 		return lexBracketName
-	case isAlpha(c):
+	case isAlphaNum(c):
 		return lexSimpleName
 	}
 	return nil // FIXME

--- a/posix_test.go
+++ b/posix_test.go
@@ -156,8 +156,8 @@ func TestExpand_simple(t *testing.T) {
 		"null": "",
 		"1":    "one",
 		"2":    "two",
-		"11":    "eleven",
-		"22":    "twenty-two",
+		"11":   "eleven",
+		"22":   "twenty-two",
 	}
 
 	for _, tt := range paramtests {
@@ -175,7 +175,7 @@ func TestExpand_simple(t *testing.T) {
 	}
 }
 
-func TestExand_assignReadOnlyFunc(t *testing.T) {
+func TestExpand_assignReadOnlyFunc(t *testing.T) {
 	_, err := Expand("${unset:=word}", Func(func(s string) string {
 		return ""
 	}))
@@ -184,7 +184,7 @@ func TestExand_assignReadOnlyFunc(t *testing.T) {
 	}
 }
 
-func TestExand_assignReadOnlyMap(t *testing.T) {
+func TestExpand_assignReadOnlyMap(t *testing.T) {
 	_, err := Expand("${unset:=word}", Map(nil))
 	if err == nil {
 		t.Fatal("assignment on read-only map should return an error")

--- a/posix_test.go
+++ b/posix_test.go
@@ -206,3 +206,28 @@ func TestExpand_assign(t *testing.T) {
 	equals(t, "word", x)
 	equals(t, map[string]string{"unset": "word"}, mapping)
 }
+
+func TestExpand_shellPositionalArg(t *testing.T) {
+	mapping := map[string]string{
+		"1": "foo",
+		"2": "bar",
+	}
+
+	params := []struct {
+		in  string
+		out string
+	}{
+		{"$1$2", "foobar"},
+		{"/home/$1/$2", "/home/foo/bar"},
+	}
+
+	for _, tt := range params {
+		x, err := Expand(tt.in, Map(mapping))
+		if err != nil {
+			t.Errorf("pattern %#v should not have produced an error, but got: %s", tt.in, err)
+		}
+		if x != tt.out {
+			t.Errorf("pattern %#v should expand to %#v, but got %#v", tt.in, tt.out, x)
+		}
+	}
+}

--- a/posix_test.go
+++ b/posix_test.go
@@ -36,11 +36,13 @@ var paramtests = []struct {
 	{"${null}", "", ""},
 	{"${unset}", "", ""},
 	{"${1}X${2}", "oneXtwo", ""},
+	{"${11}X${22}", "elevenXtwenty-two", ""},
 
 	// Names, no brackets
 	{"$set", "yes", ""},
 	{"$set$set2", "yesyes-two", ""},
-	// {"$1X$2", "oneXtwo", ""}, // TODO(#3) parse numeric simple names
+	{"$1X$2", "oneXtwo", ""},
+	{"$11X$22", "elevenXtwenty-two", ""},
 
 	// Default
 	{"${set:-word}", "yes", ""},
@@ -154,6 +156,8 @@ func TestExpand_simple(t *testing.T) {
 		"null": "",
 		"1":    "one",
 		"2":    "two",
+		"11":    "eleven",
+		"22":    "twenty-two",
 	}
 
 	for _, tt := range paramtests {
@@ -205,29 +209,4 @@ func TestExpand_assign(t *testing.T) {
 	ok(t, err)
 	equals(t, "word", x)
 	equals(t, map[string]string{"unset": "word"}, mapping)
-}
-
-func TestExpand_shellPositionalArg(t *testing.T) {
-	mapping := map[string]string{
-		"1": "foo",
-		"2": "bar",
-	}
-
-	params := []struct {
-		in  string
-		out string
-	}{
-		{"$1$2", "foobar"},
-		{"/home/$1/$2", "/home/foo/bar"},
-	}
-
-	for _, tt := range params {
-		x, err := Expand(tt.in, Map(mapping))
-		if err != nil {
-			t.Errorf("pattern %#v should not have produced an error, but got: %s", tt.in, err)
-		}
-		if x != tt.out {
-			t.Errorf("pattern %#v should expand to %#v, but got %#v", tt.in, tt.out, x)
-		}
-	}
 }


### PR DESCRIPTION
Closes #3 
Added tests for numbered expansion variables and fixed a formatting verb for `p.op` rune.